### PR TITLE
Check if weak reference is nil prior to passing to C APIs

### DIFF
--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -341,7 +341,7 @@ void KWClearObjectStubs(id anObject) {
 void KWClearAllObjectStubs(void) {
     for (KWInterceptedObjectBlock key in KWObjectStubs) {
         id stubbedObject = key();
-        if (KWObjectClassRestored(stubbedObject)) {
+        if (stubbedObject == nil || KWObjectClassRestored(stubbedObject)) {
             continue;
         }
         KWRestoreOriginalClass(stubbedObject);


### PR DESCRIPTION
# Summary

We are seeing intermittent test failures in specs, crashing with `EXC_BAD_ACCESS`. The root cause of these failures to be a memory management bug within Kiwi.

---

Kiwi internally keeps an `NSMapTable` of stubbed objects and their associated stubs. Each key in this map table is a block which returns a weak reference to the stubbed object. This is presumably done to avoid [limitations with weak keys in `NSMapTable`](https://developer.apple.com/documentation/foundation/nsmaptable/1391346-weaktostrongobjects#discussion).

Upon completion of each test, Kiwi clears all stubs and spies by calling `KWClearStubsAndSpies`. This calls down into `KWClearAllObjectStubs`, which iterates through the map table to restore the stubbed object's class:

```
void KWClearAllObjectStubs(void) {
    for (KWInterceptedObjectBlock key in KWObjectStubs) {
        id stubbedObject = key();
        if (KWObjectClassRestored(stubbedObject)) {
            continue;
        }
        KWRestoreOriginalClass(stubbedObject);
    }
    [KWObjectStubs removeAllObjects];
}
```

The issue here is that `stubbedObject` (a weak reference) can potentially be equal to `nil`. For regular Objective-C code, this is fine (messages to `nil` are essentially no-op). However, Kiwi passes `stubbedObject` to `KWObjectClassRestored`, and then `KWInterceptedObjectKey`.

Looking at the implementation of `KWInterceptedObjectKey`:

```
KWInterceptedObjectBlock KWInterceptedObjectKey(id anObject) {
    KWInterceptedObjectBlock key = objc_getAssociatedObject(anObject, kKWInterceptedObjectKey);
    if (key == nil) {
        __weak id weakobj = anObject;
        key = ^{ return weakobj; };
        objc_setAssociatedObject(anObject, kKWInterceptedObjectKey, [key copy], OBJC_ASSOCIATION_COPY);
    }
    return key;
}
```

In the case that `anObject` is nil, `key` will also be `nil`. This causes the code inside the if statement to be executed, which then calls `objc_setAssociatedObject` on a `nil` object. This results in an internal null-dereference, which crashes the application.

---

# Solution

This bug can be fixed by first checking if `stubbedObject` is `nil` inside the loop in `KWClearAllObjectStubs`, and ignoring it if so. For example:

```
void KWClearAllObjectStubs(void) {
    for (KWInterceptedObjectBlock key in KWObjectStubs) {
        id stubbedObject = key();
        if (stubbedObject == nil  || KWObjectClassRestored(stubbedObject)) {
            continue;
        }
        KWRestoreOriginalClass(stubbedObject);
    }
    [KWObjectStubs removeAllObjects];
}
```

Such a fix would require forking Kiwi and/or submitting a fix for the issue to upstream.